### PR TITLE
Refresh jwt token

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -10,7 +10,6 @@ export default defineConfig([
             "dist/**",
             "node_modules/**",
             "src/db/migrations/",
-            "tests/",
             "src/db/config.ts",
         ],
     },

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,14 +4,6 @@ import { compilerOptions } from "./tsconfig.json";
 
 import type { Config } from "jest";
 
-// export default {
-//     preset: "ts-jest",
-//     testEnvironment: "node",
-//     globalSetup: "./jest/globalSetup.ts",
-//     globalTeardown: "./jest/globalTeardown.ts",
-//     setupFilesAfterEnv: ["./jest/setupTests.ts"],
-// };
-
 const config: Config = {
     preset: "ts-jest",
     testEnvironment: "node",
@@ -21,6 +13,7 @@ const config: Config = {
     moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
         prefix: "<rootDir>/",
     }),
+    testPathIgnorePatterns: ["./dist"],
 };
 
 export default config;

--- a/src/controllers/auth/refreshToken.ts
+++ b/src/controllers/auth/refreshToken.ts
@@ -1,5 +1,26 @@
 import { Request, Response } from "express";
+import jwt from "jsonwebtoken";
 
-function refreshJWToken(_req: Request, _res: Response): void {}
+import { issueJWTokens } from "./services/jwt";
+
+async function refreshJWToken(req: Request, res: Response): Promise<void> {
+    const refreshToken = req.signedCookies.refresh;
+    try {
+        jwt.verify(refreshToken, process.env.REFRESH_TOKEN_SECRET_KEY!);
+    } catch {
+        res.status(401).json({
+            status: "error",
+            message: "Invalid refresh token",
+        });
+        return;
+    }
+    const { access, refresh } = issueJWTokens(res.locals.userId);
+    res.cookie("refresh", refresh, {
+        httpOnly: true,
+        signed: true,
+        secure: process.env.NODE_ENV === "production",
+    });
+    res.status(200).json({ access: access });
+}
 
 export default refreshJWToken;

--- a/src/controllers/auth/signIn.ts
+++ b/src/controllers/auth/signIn.ts
@@ -17,7 +17,7 @@ async function signInController(req: Request, res: Response): Promise<void> {
         res.cookie("refresh", refresh, {
             httpOnly: true,
             signed: true,
-            secure: true,
+            secure: process.env.NODE_ENV === "production",
         });
         res.status(200).json({ access: access });
     } else {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -22,6 +22,6 @@ authRouter.post(
     signUpController
 );
 authRouter.get("/activate", query("token").isUUID(4), activateUserController);
-authRouter.post("/refreshToken", refreshJWToken);
+authRouter.post("/refresh", refreshJWToken);
 
 export default authRouter;

--- a/src/tests/auth/activateUser.test.ts
+++ b/src/tests/auth/activateUser.test.ts
@@ -5,8 +5,7 @@ import app from "@/app";
 import { generateExpirationDate } from "@/controllers/auth/services/signUp";
 import ConfirmationTokenRepo from "@/db/models/repos/ConfirmationToken";
 import UserRepo from "@/db/models/repos/user";
-
-import createUserAndLogin from "../services/auth";
+import createUserAndLogin from "@/tests/services/auth";
 
 describe("GET /auth/activate?token=*", () => {
     it("has to activate an inactive user", async () => {

--- a/src/tests/auth/refreshJWT.test.ts
+++ b/src/tests/auth/refreshJWT.test.ts
@@ -1,0 +1,18 @@
+import request from "supertest";
+
+import app from "@/app";
+
+import createUserAndLogin from "../services/auth";
+
+describe("POST /auth/refresh", () => {
+    it("has to issue new AccessJWT using RefreshJWT from httpOnly cookies", async () => {
+        const agent = request.agent(app);
+        await createUserAndLogin({ isActive: true }, agent);
+        const refreshTokenRes = await agent.post("/auth/refresh");
+        expect(refreshTokenRes.body).toEqual(
+            expect.objectContaining({
+                access: expect.any(String),
+            })
+        );
+    });
+});

--- a/src/tests/auth/signin.test.ts
+++ b/src/tests/auth/signin.test.ts
@@ -1,8 +1,9 @@
-import createUserAndLogin from "../services/auth";
+import createUserAndLogin from "@/tests/services/auth";
 
 describe("POST /auth/signin", () => {
     it("must return access and refresh token", async () => {
         const { response } = await createUserAndLogin({ isActive: true });
         expect(response.status).toStrictEqual(200);
+        expect(response.body).toMatchObject({ access: response.body.access });
     });
 });

--- a/src/tests/services/auth.ts
+++ b/src/tests/services/auth.ts
@@ -1,9 +1,13 @@
-import request from "supertest";
+import request, { Test } from "supertest";
+import TestAgent from "supertest/lib/agent";
 
 import app from "@/app";
 import UserRepo from "@/db/models/repos/user";
 
-async function createUserAndLogin(userDataOverride = {}) {
+async function createUserAndLogin(
+    userDataOverride = {},
+    agent?: TestAgent<Test>
+) {
     const userData = {
         email: "test@gmail.com",
         username: "levinsxn",
@@ -14,7 +18,8 @@ async function createUserAndLogin(userDataOverride = {}) {
     const userRepo = new UserRepo();
     const user = await userRepo.create({ ...userData });
 
-    const signInRes = await request(app)
+    const requestAgent = agent ? agent : request(app);
+    const signInRes = await requestAgent
         .post("/auth/signin")
         .send({ username: userData.username, password: userData.password });
     return { response: signInRes, user: user };

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -1,5 +1,0 @@
-extends layout
-
-block content
-  h1= title
-  p Welcome to #{title}


### PR DESCRIPTION
## 📄 Description

At this PR I have provided controller to have possibility to update refresh token.

---

## 🚀 Changes

- [ ] Code formatting
- [ ] New models added
- [ ] Model fields updated
- [ ] New controllers/routes added
- [ ] Existing controllers/routes modified

---

## ✅ Tests

- [ ] All tests pass
- [ ] New tests added
- [ ] Existing tests updated

---

## 🧪 How to test this PR

1. Sign up specifying username, email and password at `POST /auth/signup`.
2. Click at the link that was sent to the specified email
3. Sign in using provided credentials at `POST /auth/signin` by `username`
4. Update refresh token sending empty request to `POST /auth/refresh`
